### PR TITLE
add Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Following is a growing list of some of the materials I found on the web for rese
 4. [cuda-convnet](https://code.google.com/p/cuda-convnet/)
 5. [MXNET](https://github.com/dmlc/mxnet/)
 6. [Tensorflow](https://github.com/tensorflow)
+7. [tiny-dnn](https://github.com/tiny-dnn/tiny-dnn)
 
 ##Miscellaneous
 


### PR DESCRIPTION
tiny-dnn is header only, dependency-free deep learning framework in C++11
