### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Face-Resources
 Following is a growing list of some of the materials I found on the web for research on face recognition algorithm.
 
-##Papers
+## Papers
 
 1. [DeepFace](https://www.cs.toronto.edu/~ranzato/publications/taigman_cvpr14.pdf).A work from Facebook.
 2. [FaceNet](http://www.cv-foundation.org/openaccess/content_cvpr_2015/app/1A_089.pdf).A work from Google.
@@ -13,7 +13,7 @@ Following is a growing list of some of the materials I found on the web for rese
 8. [Face Search at Scale: 80 Million Gallery](http://arxiv.org/abs/1507.07242)
 9. [A Discriminative Feature Learning Approach for Deep Face Recognition](http://ydwen.github.io/papers/WenECCV16.pdf)
 
-##Datasets
+## Datasets
 
 1. [CASIA WebFace Database](http://www.cbsr.ia.ac.cn/english/CASIA-WebFace-Database.html). 10,575 subjects and 494,414 images
 2. [Labeled Faces in the Wild](http://vis-www.cs.umass.edu/lfw/).13,000 images and 5749 subjects
@@ -37,18 +37,18 @@ Following is a growing list of some of the materials I found on the web for rese
 
 
 
-##Trained Model
+## Trained Model
 
 1. [openface](https://github.com/cmusatyalab/openface). Face recognition with Google's FaceNet deep neural network using Torch.
 2. [VGG-Face](http://www.robots.ox.ac.uk/~vgg/software/vgg_face/). VGG-Face CNN descriptor. Impressed embedding loss.
 3. [SeetaFace Engine](https://github.com/seetaface/SeetaFaceEngine). SeetaFace Engine is an open source C++ face recognition engine, which can run on CPU with no third-party dependence. 
 4. [Caffe-face](https://github.com/ydwen/caffe-face) - Caffe Face is developed for face recognition using deep neural networks. 
 
-##Tutorial
+## Tutorial
 
 1. [Deep Learning for Face Recognition](http://valse.mmcheng.net/deep-learning-for-face-recognition/). Shiguan Shan, Xiaogang Wang, and Ming yang.
 
-##Software
+## Software
 
 1. [OpenCV](http://opencv.org/). With some trained face detector models.
 2. [dlib](http://dlib.net/ml.html). Dlib implements a state-of-the-art of face Alignment algorithm.
@@ -56,7 +56,7 @@ Following is a growing list of some of the materials I found on the web for rese
 4. [libfacedetection](https://github.com/ShiqiYu/libfacedetection). A binary library for face detection in images.
 5. [SeetaFaceEngine](https://github.com/seetaface/SeetaFaceEngine). An open source C++ face recognition engine.
 
-##Frameworks
+## Frameworks
 
 1. [Caffe](http://caffe.berkeleyvision.org/)
 2. [Torch7](https://github.com/torch/torch7)
@@ -66,7 +66,7 @@ Following is a growing list of some of the materials I found on the web for rese
 6. [Tensorflow](https://github.com/tensorflow)
 7. [tiny-dnn](https://github.com/tiny-dnn/tiny-dnn)
 
-##Miscellaneous
+## Miscellaneous
 
 1. [faceswap](https://github.com/matthewearl/faceswap)  Face swapping with Python, dlib, and OpenCV
 2. [Facial Keypoints Detection](https://www.kaggle.com/c/facial-keypoints-detection/details/deep-learning-tutorial) Competition on Kaggle.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
